### PR TITLE
No default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,5 @@ jobs:
         run: cargo build
       - name: Run tests
         run: cargo nextest run
+      - name: Run tests (without default features)
+        run: cargo nextest run --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ edition = "2021"
 rust-version = "1.70"
 
 [features]
-default = ["timestamps", "uuids"]
+default = ["timestamps", "uuids", "strip-ansi"]
 timestamps = ["dep:chrono"]
 uuids = ["dep:uuid", "dep:newtype-uuid"]
+strip-ansi = ["dep:strip-ansi-escapes"]
 
 [dependencies]
 chrono = { version = "0.4.41", default-features = false, features = ["std"], optional = true }
@@ -22,7 +23,7 @@ indexmap = "2.7.1"
 quick-xml = "0.38.1"
 newtype-uuid = { version = "1.2.4", optional = true }
 thiserror = "2.0.12"
-strip-ansi-escapes = "0.2.1"
+strip-ansi-escapes = { version = "0.2.1", optional = true }
 uuid = { version = "1.17.0", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ edition = "2021"
 rust-version = "1.70"
 
 [features]
-default = ["uuids"]
+default = ["timestamps", "uuids"]
+timestamps = ["dep:chrono"]
 uuids = ["dep:uuid", "dep:newtype-uuid"]
 
 [dependencies]
-chrono = { version = "0.4.41", default-features = false, features = ["std"] }
+chrono = { version = "0.4.41", default-features = false, features = ["std"], optional = true }
 indexmap = "2.7.1"
 quick-xml = "0.38.1"
 newtype-uuid = { version = "1.2.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,18 @@ categories = ["encoding", "development-tools"]
 edition = "2021"
 rust-version = "1.70"
 
+[features]
+default = ["uuids"]
+uuids = ["dep:uuid", "dep:newtype-uuid"]
+
 [dependencies]
 chrono = { version = "0.4.41", default-features = false, features = ["std"] }
 indexmap = "2.7.1"
 quick-xml = "0.38.1"
-newtype-uuid = "1.2.4"
+newtype-uuid = { version = "1.2.4", optional = true }
 thiserror = "2.0.12"
 strip-ansi-escapes = "0.2.1"
-uuid = "1.17.0"
+uuid = { version = "1.17.0", optional = true }
 
 [dev-dependencies]
 goldenfile = "1.7.3"

--- a/src/report.rs
+++ b/src/report.rs
@@ -4,13 +4,17 @@
 use crate::{serialize::serialize_report, SerializeError};
 use chrono::{DateTime, FixedOffset};
 use indexmap::map::IndexMap;
+#[cfg(feature = "uuids")]
 use newtype_uuid::{GenericUuid, TypedUuid, TypedUuidKind, TypedUuidTag};
 use std::{borrow::Borrow, hash::Hash, io, iter, ops::Deref, time::Duration};
+#[cfg(feature = "uuids")]
 use uuid::Uuid;
 
 /// A tag indicating the kind of report.
+#[cfg(feature = "uuids")]
 pub enum ReportKind {}
 
+#[cfg(feature = "uuids")]
 impl TypedUuidKind for ReportKind {
     fn tag() -> TypedUuidTag {
         const TAG: TypedUuidTag = TypedUuidTag::new("quick-junit-report");
@@ -19,6 +23,7 @@ impl TypedUuidKind for ReportKind {
 }
 
 /// A unique identifier associated with a report.
+#[cfg(feature = "uuids")]
 pub type ReportUuid = TypedUuid<ReportKind>;
 
 /// The root element of a JUnit report.
@@ -30,6 +35,7 @@ pub struct Report {
     /// A unique identifier associated with this report.
     ///
     /// This is an extension to the spec that's used by nextest.
+    #[cfg(feature = "uuids")]
     pub uuid: Option<ReportUuid>,
 
     /// The time at which the first test in this report began execution.
@@ -60,6 +66,7 @@ impl Report {
     pub fn new(name: impl Into<XmlString>) -> Self {
         Self {
             name: name.into(),
+            #[cfg(feature = "uuids")]
             uuid: None,
             timestamp: None,
             time: None,
@@ -73,6 +80,7 @@ impl Report {
     /// Sets a unique ID for this `Report`.
     ///
     /// This is an extension that's used by nextest.
+    #[cfg(feature = "uuids")]
     pub fn set_report_uuid(&mut self, uuid: ReportUuid) -> &mut Self {
         self.uuid = Some(uuid);
         self
@@ -81,6 +89,7 @@ impl Report {
     /// Sets a unique ID for this `Report` from an untyped [`Uuid`].
     ///
     /// This is an extension that's used by nextest.
+    #[cfg(feature = "uuids")]
     pub fn set_uuid(&mut self, uuid: Uuid) -> &mut Self {
         self.uuid = Some(ReportUuid::from_untyped_uuid(uuid));
         self

--- a/src/report.rs
+++ b/src/report.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{serialize::serialize_report, SerializeError};
+#[cfg(feature = "timestamps")]
 use chrono::{DateTime, FixedOffset};
 use indexmap::map::IndexMap;
 #[cfg(feature = "uuids")]
@@ -41,6 +42,7 @@ pub struct Report {
     /// The time at which the first test in this report began execution.
     ///
     /// This is not part of the JUnit spec, but may be useful for some tools.
+    #[cfg(feature = "timestamps")]
     pub timestamp: Option<DateTime<FixedOffset>>,
 
     /// The overall time taken by the test suite.
@@ -68,6 +70,7 @@ impl Report {
             name: name.into(),
             #[cfg(feature = "uuids")]
             uuid: None,
+            #[cfg(feature = "timestamps")]
             timestamp: None,
             time: None,
             tests: 0,
@@ -96,6 +99,7 @@ impl Report {
     }
 
     /// Sets the start timestamp for the report.
+    #[cfg(feature = "timestamps")]
     pub fn set_timestamp(&mut self, timestamp: impl Into<DateTime<FixedOffset>>) -> &mut Self {
         self.timestamp = Some(timestamp.into());
         self
@@ -174,6 +178,7 @@ pub struct TestSuite {
     pub failures: usize,
 
     /// The time at which the TestSuite began execution.
+    #[cfg(feature = "timestamps")]
     pub timestamp: Option<DateTime<FixedOffset>>,
 
     /// The overall time taken by the TestSuite.
@@ -201,6 +206,7 @@ impl TestSuite {
         Self {
             name: name.into(),
             time: None,
+            #[cfg(feature = "timestamps")]
             timestamp: None,
             tests: 0,
             disabled: 0,
@@ -215,6 +221,7 @@ impl TestSuite {
     }
 
     /// Sets the start timestamp for the TestSuite.
+    #[cfg(feature = "timestamps")]
     pub fn set_timestamp(&mut self, timestamp: impl Into<DateTime<FixedOffset>>) -> &mut Self {
         self.timestamp = Some(timestamp.into());
         self
@@ -318,6 +325,7 @@ pub struct TestCase {
     /// The time at which this test case began execution.
     ///
     /// This is not part of the JUnit spec, but may be useful for some tools.
+    #[cfg(feature = "timestamps")]
     pub timestamp: Option<DateTime<FixedOffset>>,
 
     /// The time it took to execute this test case.
@@ -346,6 +354,7 @@ impl TestCase {
             name: name.into(),
             classname: None,
             assertions: None,
+            #[cfg(feature = "timestamps")]
             timestamp: None,
             time: None,
             status,
@@ -369,6 +378,7 @@ impl TestCase {
     }
 
     /// Sets the start timestamp for the test case.
+    #[cfg(feature = "timestamps")]
     pub fn set_timestamp(&mut self, timestamp: impl Into<DateTime<FixedOffset>>) -> &mut Self {
         self.timestamp = Some(timestamp.into());
         self
@@ -557,6 +567,7 @@ pub struct TestRerun {
     /// The time at which this rerun began execution.
     ///
     /// This is not part of the JUnit spec, but may be useful for some tools.
+    #[cfg(feature = "timestamps")]
     pub timestamp: Option<DateTime<FixedOffset>>,
 
     /// The time it took to execute this rerun.
@@ -590,6 +601,7 @@ impl TestRerun {
     pub fn new(kind: NonSuccessKind) -> Self {
         TestRerun {
             kind,
+            #[cfg(feature = "timestamps")]
             timestamp: None,
             time: None,
             message: None,
@@ -602,6 +614,7 @@ impl TestRerun {
     }
 
     /// Sets the start timestamp for this rerun.
+    #[cfg(feature = "timestamps")]
     pub fn set_timestamp(&mut self, timestamp: impl Into<DateTime<FixedOffset>>) -> &mut Self {
         self.timestamp = Some(timestamp.into());
         self

--- a/src/report.rs
+++ b/src/report.rs
@@ -740,6 +740,7 @@ impl XmlString {
     /// Creates a new `XmlString`, removing any ANSI escapes and non-printable characters from it.
     pub fn new(data: impl AsRef<str>) -> Self {
         let data = data.as_ref();
+        #[cfg(feature = "strip-ansi")]
         let data = strip_ansi_escapes::strip_str(data);
         let data = data
             .replace(

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -7,6 +7,7 @@ use crate::{
     NonSuccessKind, Property, Report, SerializeError, TestCase, TestCaseStatus, TestRerun,
     TestSuite, XmlString,
 };
+#[cfg(feature = "timestamps")]
 use chrono::{DateTime, FixedOffset};
 use quick_xml::{
     events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event},
@@ -54,6 +55,7 @@ pub(crate) fn serialize_report_impl(
         name,
         #[cfg(feature = "uuids")]
         uuid,
+        #[cfg(feature = "timestamps")]
         timestamp,
         time,
         tests,
@@ -73,6 +75,7 @@ pub(crate) fn serialize_report_impl(
     if let Some(uuid) = uuid {
         testsuites_tag.push_attribute(("uuid", uuid.to_string().as_str()));
     }
+    #[cfg(feature = "timestamps")]
     if let Some(timestamp) = timestamp {
         serialize_timestamp(&mut testsuites_tag, timestamp);
     }
@@ -103,6 +106,7 @@ pub(crate) fn serialize_test_suite(
         errors,
         failures,
         time,
+        #[cfg(feature = "timestamps")]
         timestamp,
         test_cases,
         properties,
@@ -120,6 +124,7 @@ pub(crate) fn serialize_test_suite(
         ("failures", failures.to_string().as_str()),
     ]);
 
+    #[cfg(feature = "timestamps")]
     if let Some(timestamp) = timestamp {
         serialize_timestamp(&mut test_suite_tag, timestamp);
     }
@@ -174,6 +179,7 @@ fn serialize_test_case(
         name,
         classname,
         assertions,
+        #[cfg(feature = "timestamps")]
         timestamp,
         time,
         status,
@@ -192,6 +198,7 @@ fn serialize_test_case(
         testcase_tag.push_attribute(("assertions", format!("{assertions}").as_str()));
     }
 
+    #[cfg(feature = "timestamps")]
     if let Some(timestamp) = timestamp {
         serialize_timestamp(&mut testcase_tag, timestamp);
     }
@@ -308,6 +315,7 @@ fn serialize_rerun(
     writer: &mut Writer<impl io::Write>,
 ) -> quick_xml::Result<()> {
     let TestRerun {
+        #[cfg(feature = "timestamps")]
         timestamp,
         time,
         kind,
@@ -327,6 +335,7 @@ fn serialize_rerun(
     };
 
     let mut tag = BytesStart::new(tag_name);
+    #[cfg(feature = "timestamps")]
     if let Some(timestamp) = timestamp {
         serialize_timestamp(&mut tag, timestamp);
     }
@@ -411,6 +420,7 @@ fn serialize_end_tag(
     writer.write_event(Event::End(end_tag))
 }
 
+#[cfg(feature = "timestamps")]
 fn serialize_timestamp(tag: &mut BytesStart<'_>, timestamp: &DateTime<FixedOffset>) {
     // The format string is obtained from https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html#fn8.
     // The only change is that this only prints timestamps up to 3 decimal places (to match times).

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -52,6 +52,7 @@ pub(crate) fn serialize_report_impl(
     // Use the destructuring syntax to ensure that all fields are handled.
     let Report {
         name,
+        #[cfg(feature = "uuids")]
         uuid,
         timestamp,
         time,
@@ -68,6 +69,7 @@ pub(crate) fn serialize_report_impl(
         ("failures", failures.to_string().as_str()),
         ("errors", errors.to_string().as_str()),
     ]);
+    #[cfg(feature = "uuids")]
     if let Some(uuid) = uuid {
         testsuites_tag.push_attribute(("uuid", uuid.to_string().as_str()));
     }

--- a/tests/fixture_tests.rs
+++ b/tests/fixture_tests.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#[cfg(feature = "timestamps")]
 use chrono::DateTime;
 use goldenfile::Mint;
 use owo_colors::OwoColorize;
@@ -13,8 +14,13 @@ use std::time::Duration;
 fn fixtures() {
     let mut mint = Mint::new("tests/fixtures");
 
+    #[cfg(all(feature = "timestamps", feature = "uuids", feature = "strip-ansi"))]
     let f = mint
         .new_goldenfile("basic_report.xml")
+        .expect("creating new goldenfile succeeds");
+    #[cfg(not(any(feature = "timestamps", feature = "uuids", feature = "strip-ansi")))]
+    let f = mint
+        .new_goldenfile("basic_report_no_default_features.xml")
         .expect("creating new goldenfile succeeds");
 
     let basic_report = basic_report();
@@ -25,6 +31,7 @@ fn fixtures() {
 
 fn basic_report() -> Report {
     let mut report = Report::new("my-test-run");
+    #[cfg(feature = "timestamps")]
     report.set_timestamp(
         DateTime::parse_from_rfc2822("Thu, 1 Apr 2021 10:52:37 -0800")
             .expect("valid RFC2822 datetime"),
@@ -32,6 +39,7 @@ fn basic_report() -> Report {
     report.set_time(Duration::new(42, 234_567_890));
 
     let mut test_suite = TestSuite::new("testsuite0");
+    #[cfg(feature = "timestamps")]
     test_suite.set_timestamp(
         DateTime::parse_from_rfc2822("Thu, 1 Apr 2021 10:52:39 -0800")
             .expect("valid RFC2822 datetime"),
@@ -74,11 +82,13 @@ fn basic_report() -> Report {
         .set_message("skipped message");
     // no description to test that.
     let mut test_case = TestCase::new("testcase3", test_case_status);
+    #[cfg(feature = "timestamps")]
     test_case
         .set_timestamp(
             DateTime::parse_from_rfc2822("Thu, 1 Apr 2021 11:52:41 -0700")
                 .expect("valid RFC2822 datetime"),
-        )
+        );
+    test_case
         .set_assertions(20)
         .set_system_out("testcase3 output")
         .set_system_err("testcase3 error");
@@ -138,6 +148,8 @@ fn basic_report() -> Report {
     test_suite.add_property(Property::new("env", "FOOBAR"));
 
     report.add_test_suite(test_suite);
+    #[cfg(feature = "uuids")]
+    report.set_uuid(uuid::Uuid::parse_str("0500990f-0df3-4722-bbeb-90a75b8aa6bd").expect("uuid parsing succeeds"));
 
     report
 }

--- a/tests/fixtures/basic_report_no_default_features.xml
+++ b/tests/fixtures/basic_report_no_default_features.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="my-test-run" tests="7" failures="2" errors="1" uuid="0500990f-0df3-4722-bbeb-90a75b8aa6bd" timestamp="2021-04-01T10:52:37.000-08:00" time="42.235">
-    <testsuite name="testsuite0" tests="7" disabled="1" errors="1" failures="2" timestamp="2021-04-01T10:52:39.000-08:00">
+<testsuites name="my-test-run" tests="7" failures="2" errors="1" time="42.235">
+    <testsuite name="testsuite0" tests="7" disabled="1" errors="1" failures="2">
         <properties>
             <property name="env" value="FOOBAR"/>
         </properties>
@@ -14,7 +14,7 @@
         <testcase name="testcase2" time="0.000">
             <error type="error type">testcase2 error description</error>
         </testcase>
-        <testcase name="testcase3" assertions="20" timestamp="2021-04-01T11:52:41.000-07:00">
+        <testcase name="testcase3" assertions="20">
             <skipped message="skipped message" type="skipped type"/>
             <system-out>testcase3 output</system-out>
             <system-err>testcase3 error</system-err>
@@ -24,7 +24,7 @@
             <flakyError type="flaky error type">flaky error description
                 <stackTrace>flaky stack trace</stackTrace>
                 <system-out>flaky system output</system-out>
-                <system-err>flaky system error with ANSI escape codes</system-err>
+                <system-err>flaky system error with [34mANSI escape codes[39m</system-err>
             </flakyError>
         </testcase>
         <testcase name="testcase5" time="0.156">


### PR DESCRIPTION
This PR fixes https://github.com/nextest-rs/quick-junit/issues/429. I've moved uuid, chrono and strip-ansi-escapes into optional (on-by-default) features, and then made sure this configuration is tested in CI as well.

Thank you for building and maintaining quick-junit! 🍰 