### PR TITLE
serialize childless testsuite and testcase elements as self-closing tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+### Changed
+
+- Childless `<testsuite>` and `<testcase>` elements are now serialized as self-closing tags (for example, `<testcase name="my-test"/>` rather than `<testcase name="my-test"></testcase>`). The output is semantically identical XML, only more compact and idiomatic. The deserializer already accepted these self-closing forms, so serializing them means round-trip tests now cover those parse paths.
+
 ## [0.6.1] - 2026-07-02
 
 ### Updated

--- a/crates/quick-junit-tests/tests/integration/main.rs
+++ b/crates/quick-junit-tests/tests/integration/main.rs
@@ -5,4 +5,5 @@ mod cdata;
 mod deserialize;
 mod fixture_tests;
 mod roundtrip;
+mod self_closing;
 mod whitespace;

--- a/crates/quick-junit-tests/tests/integration/self_closing.rs
+++ b/crates/quick-junit-tests/tests/integration/self_closing.rs
@@ -1,0 +1,132 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Tests to ensure that testsuite and testcase tags are serialized in the
+//! self-closing form if and only if they truly have no children.
+
+use pretty_assertions::assert_eq;
+use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestRerun, TestSuite};
+
+#[test]
+fn childless_test_suite_serializes_self_closing() {
+    let mut suite = TestSuite::new("empty-suite");
+    suite.tests = 3;
+    suite.disabled = 1;
+
+    let mut report = Report::new("run");
+    report.add_test_suite(suite.clone());
+
+    let xml = report.to_string().expect("report serializes");
+
+    assert!(
+        xml.contains(
+            r#"<testsuite name="empty-suite" tests="3" disabled="1" errors="0" failures="0"/>"#
+        ),
+        "expected self-closing testsuite, got:\n{xml}"
+    );
+    assert!(
+        !xml.contains("</testsuite>"),
+        "childless suite should have no closing tag, got:\n{xml}"
+    );
+
+    let deserialized = Report::deserialize_from_str(&xml).expect("report round-trips");
+    assert_eq!(
+        deserialized.test_suites[0], suite,
+        "suite round-trips to an equal value"
+    );
+}
+
+#[test]
+fn childless_success_test_case_serializes_self_closing() {
+    let test_case = TestCase::new("solo", TestCaseStatus::success());
+
+    let mut suite = TestSuite::new("suite");
+    suite.add_test_case(test_case.clone());
+    let mut report = Report::new("run");
+    report.add_test_suite(suite);
+
+    let xml = report.to_string().expect("report serializes");
+
+    assert!(
+        xml.contains(r#"<testcase name="solo"/>"#),
+        "expected self-closing testcase, got:\n{xml}"
+    );
+    assert!(
+        !xml.contains("</testcase>"),
+        "childless case should have no closing tag, got:\n{xml}"
+    );
+
+    let deserialized = Report::deserialize_from_str(&xml).expect("report round-trips");
+    assert_eq!(
+        deserialized.test_suites[0].test_cases[0], test_case,
+        "case round-trips to an equal value"
+    );
+}
+
+#[test]
+fn suite_with_only_system_out_stays_expanded() {
+    // system-out is a child, so the suite must not collapse to self-closing.
+    let mut suite = TestSuite::new("suite");
+    suite.set_system_out("suite output");
+    let mut report = Report::new("run");
+    report.add_test_suite(suite);
+
+    let xml = report.to_string().expect("report serializes");
+
+    assert!(
+        xml.contains("<system-out>suite output</system-out>"),
+        "expected system-out child, got:\n{xml}"
+    );
+    assert!(
+        xml.contains("</testsuite>"),
+        "suite with system-out should stay expanded, got:\n{xml}"
+    );
+}
+
+#[test]
+fn skipped_test_case_stays_expanded() {
+    // A skipped case always emits a <skipped/> child, so it should not be
+    // serialized as a self-closing tag.
+    let test_case = TestCase::new("skip", TestCaseStatus::skipped());
+
+    let mut suite = TestSuite::new("suite");
+    suite.add_test_case(test_case);
+    let mut report = Report::new("run");
+    report.add_test_suite(suite);
+
+    let xml = report.to_string().expect("report serializes");
+
+    assert!(
+        xml.contains("<skipped/>"),
+        "expected <skipped/> child, got:\n{xml}"
+    );
+    assert!(
+        xml.contains("</testcase>"),
+        "skipped case has a child element so stays expanded, got:\n{xml}"
+    );
+}
+
+#[test]
+fn success_test_case_with_flaky_run_stays_expanded() {
+    // A flaky run is a child element, so a success case with a flaky run should
+    // not be serialized as a self-closing tag.
+    let mut status = TestCaseStatus::success();
+    status.add_rerun(TestRerun::new(NonSuccessKind::Failure));
+    let test_case = TestCase::new("flaky", status);
+
+    let mut suite = TestSuite::new("suite");
+    suite.add_test_case(test_case);
+    let mut report = Report::new("run");
+    report.add_test_suite(suite);
+
+    let xml = report.to_string().expect("report serializes");
+
+    assert!(
+        xml.contains("<flakyFailure"),
+        "expected <flakyFailure> child, got:\n{xml}"
+    );
+    assert!(
+        xml.contains("</testcase>"),
+        "success case with a flaky run stays expanded, got:\n{xml}"
+    );
+}

--- a/crates/quick-junit/README.md
+++ b/crates/quick-junit/README.md
@@ -49,8 +49,7 @@ report.add_test_suite(test_suite);
 const EXPECTED_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="my-test-run" tests="2" failures="1" errors="0">
     <testsuite name="my-test-suite" tests="2" disabled="0" errors="0" failures="1">
-        <testcase name="success-case">
-        </testcase>
+        <testcase name="success-case"/>
         <testcase name="failure-case">
             <failure/>
         </testcase>

--- a/crates/quick-junit/src/lib.rs
+++ b/crates/quick-junit/src/lib.rs
@@ -44,8 +44,7 @@
 //! const EXPECTED_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 //! <testsuites name="my-test-run" tests="2" failures="1" errors="0">
 //!     <testsuite name="my-test-suite" tests="2" disabled="0" errors="0" failures="1">
-//!         <testcase name="success-case">
-//!         </testcase>
+//!         <testcase name="success-case"/>
 //!         <testcase name="failure-case">
 //!             <failure/>
 //!         </testcase>

--- a/crates/quick-junit/src/proptest_impls.rs
+++ b/crates/quick-junit/src/proptest_impls.rs
@@ -101,6 +101,28 @@ impl Arbitrary for NonSuccessReruns {
     }
 }
 
+fn test_suite_children_strategy() -> impl Strategy<
+    Value = (
+        Vec<TestCase>,
+        Vec<Property>,
+        Option<XmlString>,
+        Option<XmlString>,
+    ),
+> {
+    prop_oneof![
+        // Weight the fully-childless case with some probability so that
+        // roundtrip proptests reliably exercise self-closing <testsuite/>
+        // serialization and its is_empty parse path.
+        1 => Just((Vec::new(), Vec::new(), None, None)),
+        7 => (
+            collection::vec(any::<TestCase>(), 0..10),
+            collection::vec(any::<Property>(), 0..5),
+            any::<Option<XmlString>>(),
+            any::<Option<XmlString>>(),
+        ),
+    ]
+}
+
 impl Arbitrary for TestSuite {
     type Parameters = ();
     type Strategy = BoxedStrategy<Self>;
@@ -110,14 +132,17 @@ impl Arbitrary for TestSuite {
             test_name_strategy(),
             option::of(datetime_strategy()),
             option::of(duration_strategy()),
-            collection::vec(any::<TestCase>(), 0..10),
-            collection::vec(any::<Property>(), 0..5),
-            any::<Option<XmlString>>(),
-            any::<Option<XmlString>>(),
+            test_suite_children_strategy(),
             collection::hash_map(xml_attr_name_strategy(), any::<XmlString>(), 0..5),
         )
             .prop_map(
-                |(name, timestamp, time, test_cases, properties, system_out, system_err, extra)| {
+                |(
+                    name,
+                    timestamp,
+                    time,
+                    (test_cases, properties, system_out, system_err),
+                    extra,
+                )| {
                     // Compute counts from test_cases
                     let tests = test_cases.len();
                     let mut failures = 0;

--- a/crates/quick-junit/src/report.rs
+++ b/crates/quick-junit/src/report.rs
@@ -436,6 +436,10 @@ pub enum TestCaseStatus {
     Success {
         /// Prior runs of the test. These are represented as `flakyFailure` or `flakyError` in the
         /// JUnit XML.
+        #[cfg_attr(
+            feature = "proptest",
+            strategy(collection::vec(any::<TestRerun>(), 0..5))
+        )]
         flaky_runs: Vec<TestRerun>,
     },
 

--- a/crates/quick-junit/src/serialize.rs
+++ b/crates/quick-junit/src/serialize.rs
@@ -129,6 +129,19 @@ pub(crate) fn serialize_test_suite(
         test_suite_tag.push_attribute((k.as_str(), v.as_str()));
     }
 
+    // A childless testsuite is treated as a self-closing tag.
+    //
+    // This check mirrors the event processing below -- it must stay in sync.
+    // (The roundtrip proptests are intended to catch regressions here.)
+    if properties.is_empty()
+        && test_cases.is_empty()
+        && system_out.is_none()
+        && system_err.is_none()
+    {
+        writer.write_event(Event::Empty(test_suite_tag))?;
+        return Ok(());
+    }
+
     writer.write_event(Event::Start(test_suite_tag))?;
 
     if !properties.is_empty() {
@@ -200,6 +213,22 @@ fn serialize_test_case(
     for (k, v) in extra {
         testcase_tag.push_attribute((k.as_str(), v.as_str()));
     }
+
+    // A childless testsuite is treated as a self-closing tag.
+    //
+    // This check mirrors the event processing below -- it must stay in sync.
+    // (The roundtrip proptests are intended to catch regressions here.)
+    let status_has_children = match status {
+        TestCaseStatus::Success { flaky_runs } => !flaky_runs.is_empty(),
+        TestCaseStatus::NonSuccess { .. } => true,
+        TestCaseStatus::Skipped { .. } => true,
+    };
+    if properties.is_empty() && system_out.is_none() && system_err.is_none() && !status_has_children
+    {
+        writer.write_event(Event::Empty(testcase_tag))?;
+        return Ok(());
+    }
+
     writer.write_event(Event::Start(testcase_tag))?;
 
     if !properties.is_empty() {


### PR DESCRIPTION
Also tune the proptest generators so the roundtrip tests reach these paths reliably.