### PR TITLE
aggregate counts should be skipped, not disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 
 ### Changed
 
+#### Skipped test counts
+
+Skipped test counts are now reported via the `skipped` attribute rather than `disabled`. For `<testsuite>`, `skipped` matches the [llg schema](https://llg.cubic.org/docs/junit/) and the Jenkins [junit-10 schema](https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd), as well as pytest and Maven Surefire.
+
+- Each `<testsuite>` now emits `skipped="N"`, and the root `<testsuites>` element now emits an aggregated `skipped="N"` count. Previously the root didn't carry a skip count at all.
+- Root-level `skipped` is a quick-junit extension. It follows the modern JUnit convention (as documented, for example, by [testmoapp/junitxml](https://github.com/testmoapp/junitxml)) and is similar to quick-junit's existing extensions such as `uuid`.
+- `TestSuite`'s `disabled` field has been renamed to `skipped`.
+- `Report` gains new public `skipped` and `disabled` fields, and `Report::add_test_suite` now aggregates skip counts into `Report::skipped`.
+
+`disabled` is now modeled as a separate optional count on both `Report` and `TestSuite`, distinct from `skipped`. (`disabled` is intended to count tests that are disabled by design, such as googletest's `DISABLED_`-prefixed tests. Note, however, that quick-junit doesn't have a notion of disabled tests at the moment.)
+
+#### Other changes
+
 - Childless `<testsuite>` and `<testcase>` elements are now serialized as self-closing tags (for example, `<testcase name="my-test"/>` rather than `<testcase name="my-test"></testcase>`). The output is semantically identical XML, only more compact and idiomatic. The deserializer already accepted these self-closing forms, so serializing them means round-trip tests now cover those parse paths.
 
 ## [0.6.1] - 2026-07-02

--- a/crates/quick-junit-tests/tests/fixtures/basic_report.xml
+++ b/crates/quick-junit-tests/tests/fixtures/basic_report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="my-test-run" tests="8" failures="3" errors="1" timestamp="2021-04-01T10:52:37.000-08:00" time="42.235">
-    <testsuite name="testsuite0" tests="8" disabled="1" errors="1" failures="3" timestamp="2021-04-01T10:52:39.000-08:00">
+<testsuites name="my-test-run" tests="8" skipped="1" failures="3" errors="1" timestamp="2021-04-01T10:52:37.000-08:00" time="42.235">
+    <testsuite name="testsuite0" tests="8" skipped="1" errors="1" failures="3" timestamp="2021-04-01T10:52:39.000-08:00">
         <properties>
             <property name="env" value="FOOBAR"/>
         </properties>

--- a/crates/quick-junit-tests/tests/integration/fixture_tests.rs
+++ b/crates/quick-junit-tests/tests/integration/fixture_tests.rs
@@ -182,6 +182,8 @@ fn serialize_roundtrip_examples() {
     // Verify top-level attributes.
     assert_eq!(deserialized_report.name, original_report.name);
     assert_eq!(deserialized_report.tests, original_report.tests);
+    assert_eq!(deserialized_report.skipped, original_report.skipped);
+    assert_eq!(deserialized_report.disabled, original_report.disabled);
     assert_eq!(deserialized_report.failures, original_report.failures);
     assert_eq!(deserialized_report.errors, original_report.errors);
     assert_eq!(deserialized_report.timestamp, original_report.timestamp);

--- a/crates/quick-junit-tests/tests/integration/main.rs
+++ b/crates/quick-junit-tests/tests/integration/main.rs
@@ -6,4 +6,5 @@ mod deserialize;
 mod fixture_tests;
 mod roundtrip;
 mod self_closing;
+mod skipped;
 mod whitespace;

--- a/crates/quick-junit-tests/tests/integration/self_closing.rs
+++ b/crates/quick-junit-tests/tests/integration/self_closing.rs
@@ -11,7 +11,8 @@ use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestRerun, T
 fn childless_test_suite_serializes_self_closing() {
     let mut suite = TestSuite::new("empty-suite");
     suite.tests = 3;
-    suite.disabled = 1;
+    suite.skipped = 1;
+    suite.disabled = Some(2);
 
     let mut report = Report::new("run");
     report.add_test_suite(suite.clone());
@@ -20,9 +21,9 @@ fn childless_test_suite_serializes_self_closing() {
 
     assert!(
         xml.contains(
-            r#"<testsuite name="empty-suite" tests="3" disabled="1" errors="0" failures="0"/>"#
+            r#"<testsuite name="empty-suite" tests="3" skipped="1" errors="0" failures="0" disabled="2"/>"#
         ),
-        "expected self-closing testsuite, got:\n{xml}"
+        "expected self-closing testsuite with a disabled attribute, got:\n{xml}"
     );
     assert!(
         !xml.contains("</testsuite>"),

--- a/crates/quick-junit-tests/tests/integration/skipped.rs
+++ b/crates/quick-junit-tests/tests/integration/skipped.rs
@@ -1,0 +1,215 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use pretty_assertions::assert_eq;
+use quick_junit::{DeserializeErrorKind, PathElement, Report, TestCase, TestCaseStatus, TestSuite};
+
+#[test]
+fn skipped_counts_aggregate_at_suite_and_report_level() {
+    let mut report = Report::new("skip-run");
+
+    let mut suite1 = TestSuite::new("suite1");
+    suite1.add_test_case(TestCase::new("passes", TestCaseStatus::success()));
+    suite1.add_test_case(TestCase::new("skips1", TestCaseStatus::skipped()));
+    report.add_test_suite(suite1);
+
+    let mut suite2 = TestSuite::new("suite2");
+    suite2.add_test_case(TestCase::new("skips2", TestCaseStatus::skipped()));
+    suite2.add_test_case(TestCase::new("skips3", TestCaseStatus::skipped()));
+    report.add_test_suite(suite2);
+
+    assert_eq!(report.test_suites[0].skipped, 1, "suite1 skip count");
+    assert_eq!(report.test_suites[1].skipped, 2, "suite2 skip count");
+    assert_eq!(
+        report.skipped, 3,
+        "report aggregates skip counts across suites"
+    );
+    assert_eq!(
+        report.tests, 4,
+        "report aggregates test counts across suites"
+    );
+
+    // add_test_case alters skipped but not disabled, so disabled stays None
+    // everywhere.
+    assert_eq!(
+        report.disabled, None,
+        "disabled is never populated from test cases"
+    );
+    assert_eq!(
+        report.test_suites[0].disabled, None,
+        "suite1 disabled is unset"
+    );
+    assert_eq!(
+        report.test_suites[1].disabled, None,
+        "suite2 disabled is unset"
+    );
+
+    let xml = report.to_string().expect("serialization succeeds");
+
+    assert!(
+        xml.contains(r#"<testsuites name="skip-run" tests="4" skipped="3""#),
+        "root element carries aggregated skip count, got:\n{xml}"
+    );
+    assert!(
+        xml.contains(r#"<testsuite name="suite1" tests="2" skipped="1""#),
+        "suite1 carries its own skip count, got:\n{xml}"
+    );
+    assert!(
+        xml.contains(r#"<testsuite name="suite2" tests="2" skipped="2""#),
+        "suite2 carries its own skip count, got:\n{xml}"
+    );
+    assert!(
+        !xml.contains("disabled="),
+        "the `disabled` attribute is omitted when the field is None, got:\n{xml}"
+    );
+
+    let deserialized = Report::deserialize_from_str(&xml).expect("deserialization succeeds");
+    assert_eq!(
+        deserialized, report,
+        "report round-trips through serialization"
+    );
+    assert_eq!(
+        deserialized.skipped, 3,
+        "root skip count survives round-trip"
+    );
+    assert_eq!(
+        deserialized.test_suites[1].skipped, 2,
+        "suite skip count survives round-trip"
+    );
+}
+
+// Older versions of quick-junit wrote `disabled` on `<testsuite>` as their
+// skip count, and googletest writes `disabled` on both `<testsuites>` and
+// `<testsuite>` for tests disabled by design. Both are now parsed into the
+// separate `disabled` field, leaving `skipped` at zero.
+#[test]
+fn deserialize_disabled_preserved_as_separate_count() {
+    let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="legacy" tests="2" failures="0" errors="0" disabled="2">
+    <testsuite name="suite" tests="2" disabled="2" errors="0" failures="0">
+        <testcase name="a"><skipped/></testcase>
+        <testcase name="b"><skipped/></testcase>
+    </testsuite>
+</testsuites>
+"#;
+
+    let report = Report::deserialize_from_str(xml).expect("report with disabled counts parses");
+    assert_eq!(report.skipped, 0, "root `disabled` does not feed `skipped`");
+    assert_eq!(
+        report.disabled,
+        Some(2),
+        "root `disabled` is preserved as its own count"
+    );
+    assert_eq!(
+        report.test_suites[0].skipped, 0,
+        "suite `disabled` does not feed `skipped`"
+    );
+    assert_eq!(
+        report.test_suites[0].disabled,
+        Some(2),
+        "suite `disabled` is preserved as its own count"
+    );
+}
+
+#[test]
+fn deserialize_skipped_and_disabled_are_independent() {
+    let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="both" tests="2" failures="0" errors="0" skipped="2" disabled="5">
+    <testsuite name="suite" tests="2" skipped="2" disabled="5" errors="0" failures="0">
+        <testcase name="a"><skipped/></testcase>
+        <testcase name="b"><skipped/></testcase>
+    </testsuite>
+</testsuites>
+"#;
+
+    let report = Report::deserialize_from_str(xml).expect("report parses");
+    assert_eq!(report.skipped, 2, "root skipped is its own count");
+    assert_eq!(report.disabled, Some(5), "root disabled is its own count");
+    assert_eq!(
+        report.test_suites[0].skipped, 2,
+        "suite skipped is its own count"
+    );
+    assert_eq!(
+        report.test_suites[0].disabled,
+        Some(5),
+        "suite disabled is its own count"
+    );
+
+    let xml2 = report.to_string().expect("serialization succeeds");
+    let report2 = Report::deserialize_from_str(&xml2).expect("re-parse succeeds");
+    assert_eq!(
+        report2, report,
+        "both skipped and disabled survive a serialize/deserialize round-trip"
+    );
+    assert!(
+        xml2.contains(r#"skipped="2""#) && xml2.contains(r#"disabled="5""#),
+        "serialized output carries both counts, got:\n{xml2}"
+    );
+}
+
+#[test]
+fn deserialize_invalid_suite_skipped_count() {
+    let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="test" tests="1" failures="0" errors="0">
+    <testsuite name="suite" tests="1" skipped="invalid" errors="0" failures="0">
+    </testsuite>
+</testsuites>"#;
+
+    match Report::deserialize_from_str(xml) {
+        Ok(_) => panic!("expected a parse error for malformed skipped count"),
+        Err(e) => {
+            assert!(
+                matches!(e.kind(), DeserializeErrorKind::ParseIntError(_)),
+                "expected a ParseIntError, got: {:?}",
+                e.kind()
+            );
+            assert_eq!(
+                e.path(),
+                &[
+                    PathElement::TestSuites,
+                    PathElement::TestSuite(0, None),
+                    PathElement::Attribute("skipped".to_string()),
+                ],
+                "error path points at the suite's skipped attribute"
+            );
+        }
+    }
+}
+
+#[test]
+fn add_test_suite_aggregates_disabled_counts() {
+    let mut report = Report::new("agg");
+
+    let mut suite_a = TestSuite::new("a");
+    suite_a.disabled = Some(2);
+    report.add_test_suite(suite_a);
+    assert_eq!(
+        report.disabled,
+        Some(2),
+        "first disabled count initializes the aggregate"
+    );
+
+    report.add_test_suite(TestSuite::new("b"));
+    assert_eq!(
+        report.disabled,
+        Some(2),
+        "a suite without a disabled count leaves the aggregate untouched"
+    );
+
+    let mut suite_c = TestSuite::new("c");
+    suite_c.disabled = Some(3);
+    report.add_test_suite(suite_c);
+    assert_eq!(
+        report.disabled,
+        Some(5),
+        "present disabled counts sum across suites"
+    );
+
+    let mut all_none = Report::new("all-none");
+    all_none.add_test_suite(TestSuite::new("x"));
+    all_none.add_test_suite(TestSuite::new("y"));
+    assert_eq!(
+        all_none.disabled, None,
+        "a report built from suites without disabled counts stays None"
+    );
+}

--- a/crates/quick-junit/README.md
+++ b/crates/quick-junit/README.md
@@ -31,7 +31,7 @@ The status (success, failure, error, or skipped) of a [`TestCase`](https://docs.
   * ✅ Filtering out [invalid XML
     characters](https://en.wikipedia.org/wiki/Valid_characters_in_XML) (eg ANSI escape codes)
     from the output
-* ✅ Automatically keeping track of success, failure and error counts
+* ✅ Automatically keeping track of success, failure, error, and skipped counts
 * ✅ Arbitrary properties and extra attributes
 
 ## Examples
@@ -47,8 +47,8 @@ test_suite.add_test_cases([success_case, failure_case]);
 report.add_test_suite(test_suite);
 
 const EXPECTED_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="my-test-run" tests="2" failures="1" errors="0">
-    <testsuite name="my-test-suite" tests="2" disabled="0" errors="0" failures="1">
+<testsuites name="my-test-run" tests="2" skipped="0" failures="1" errors="0">
+    <testsuite name="my-test-suite" tests="2" skipped="0" errors="0" failures="1">
         <testcase name="success-case"/>
         <testcase name="failure-case">
             <failure/>

--- a/crates/quick-junit/src/deserialize.rs
+++ b/crates/quick-junit/src/deserialize.rs
@@ -47,7 +47,7 @@ impl Report {
     ///
     /// let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
     /// <testsuites name="my-test-run" tests="1" failures="0" errors="0">
-    ///     <testsuite name="my-test-suite" tests="1" disabled="0" errors="0" failures="0">
+    ///     <testsuite name="my-test-suite" tests="1" skipped="0" errors="0" failures="0">
     ///         <testcase name="success-case"/>
     ///     </testsuite>
     /// </testsuites>
@@ -140,6 +140,8 @@ fn parse_testsuites_element(
     let mut tests = 0;
     let mut failures = 0;
     let mut errors = 0;
+    let mut skipped = 0;
+    let mut disabled: Option<usize> = None;
 
     for attr in element.attributes() {
         let attr = attr.map_err(|e| {
@@ -175,6 +177,14 @@ fn parse_testsuites_element(
                 attr_path.push(PathElement::Attribute("errors".to_string()));
                 errors = parse_usize(&attr.value, &attr_path)?;
             }
+            b"skipped" => {
+                attr_path.push(PathElement::Attribute("skipped".to_string()));
+                skipped = parse_usize(&attr.value, &attr_path)?;
+            }
+            b"disabled" => {
+                attr_path.push(PathElement::Attribute("disabled".to_string()));
+                disabled = Some(parse_usize(&attr.value, &attr_path)?);
+            }
             _ => {} // Ignore unknown attributes.
         }
     }
@@ -189,6 +199,8 @@ fn parse_testsuites_element(
         tests,
         failures,
         errors,
+        skipped,
+        disabled,
         test_suites: Vec::new(),
     })
 }
@@ -206,7 +218,8 @@ fn deserialize_test_suite<R: BufRead>(
 ) -> Result<TestSuite, DeserializeError> {
     let mut name = None;
     let mut tests = 0;
-    let mut disabled = 0;
+    let mut skipped = 0;
+    let mut disabled = None;
     let mut errors = 0;
     let mut failures = 0;
     let mut timestamp = None;
@@ -231,9 +244,13 @@ fn deserialize_test_suite<R: BufRead>(
                 attr_path.push(PathElement::Attribute("tests".to_string()));
                 tests = parse_usize(&attr.value, &attr_path)?;
             }
+            b"skipped" => {
+                attr_path.push(PathElement::Attribute("skipped".to_string()));
+                skipped = parse_usize(&attr.value, &attr_path)?;
+            }
             b"disabled" => {
                 attr_path.push(PathElement::Attribute("disabled".to_string()));
-                disabled = parse_usize(&attr.value, &attr_path)?;
+                disabled = Some(parse_usize(&attr.value, &attr_path)?);
             }
             b"errors" => {
                 attr_path.push(PathElement::Attribute("errors".to_string()));
@@ -267,6 +284,7 @@ fn deserialize_test_suite<R: BufRead>(
         return Ok(TestSuite {
             name,
             tests,
+            skipped,
             disabled,
             errors,
             failures,
@@ -354,6 +372,7 @@ fn deserialize_test_suite<R: BufRead>(
     Ok(TestSuite {
         name,
         tests,
+        skipped,
         disabled,
         errors,
         failures,

--- a/crates/quick-junit/src/lib.rs
+++ b/crates/quick-junit/src/lib.rs
@@ -26,7 +26,7 @@
 //!   - ✅ Filtering out [invalid XML
 //!     characters](https://en.wikipedia.org/wiki/Valid_characters_in_XML) (eg ANSI escape codes)
 //!     from the output
-//! - ✅ Automatically keeping track of success, failure and error counts
+//! - ✅ Automatically keeping track of success, failure, error, and skipped counts
 //! - ✅ Arbitrary properties and extra attributes
 //!
 //! # Examples
@@ -42,8 +42,8 @@
 //! report.add_test_suite(test_suite);
 //!
 //! const EXPECTED_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
-//! <testsuites name="my-test-run" tests="2" failures="1" errors="0">
-//!     <testsuite name="my-test-suite" tests="2" disabled="0" errors="0" failures="1">
+//! <testsuites name="my-test-run" tests="2" skipped="0" failures="1" errors="0">
+//!     <testsuite name="my-test-suite" tests="2" skipped="0" errors="0" failures="1">
 //!         <testcase name="success-case"/>
 //!         <testcase name="failure-case">
 //!             <failure/>

--- a/crates/quick-junit/src/proptest_impls.rs
+++ b/crates/quick-junit/src/proptest_impls.rs
@@ -132,6 +132,7 @@ impl Arbitrary for TestSuite {
             test_name_strategy(),
             option::of(datetime_strategy()),
             option::of(duration_strategy()),
+            option::of(0..=1000usize),
             test_suite_children_strategy(),
             collection::hash_map(xml_attr_name_strategy(), any::<XmlString>(), 0..5),
         )
@@ -140,6 +141,7 @@ impl Arbitrary for TestSuite {
                     name,
                     timestamp,
                     time,
+                    disabled,
                     (test_cases, properties, system_out, system_err),
                     extra,
                 )| {
@@ -147,7 +149,7 @@ impl Arbitrary for TestSuite {
                     let tests = test_cases.len();
                     let mut failures = 0;
                     let mut errors = 0;
-                    let mut disabled = 0;
+                    let mut skipped = 0;
 
                     for test_case in &test_cases {
                         match &test_case.status {
@@ -156,13 +158,14 @@ impl Arbitrary for TestSuite {
                                 NonSuccessKind::Failure => failures += 1,
                                 NonSuccessKind::Error => errors += 1,
                             },
-                            TestCaseStatus::Skipped { .. } => disabled += 1,
+                            TestCaseStatus::Skipped { .. } => skipped += 1,
                         }
                     }
 
                     TestSuite {
                         name,
                         tests,
+                        skipped,
                         disabled,
                         errors,
                         failures,
@@ -197,6 +200,15 @@ impl Arbitrary for Report {
                 let tests = test_suites.iter().map(|ts| ts.tests).sum();
                 let failures = test_suites.iter().map(|ts| ts.failures).sum();
                 let errors = test_suites.iter().map(|ts| ts.errors).sum();
+                let skipped = test_suites.iter().map(|ts| ts.skipped).sum();
+
+                // Mirror add_test_suite disabled aggregation (None if all
+                // suites None, otherwise Some of sum of present values).
+                let disabled = if test_suites.iter().all(|ts| ts.disabled.is_none()) {
+                    None
+                } else {
+                    Some(test_suites.iter().filter_map(|ts| ts.disabled).sum())
+                };
 
                 Report {
                     name,
@@ -206,6 +218,8 @@ impl Arbitrary for Report {
                     tests,
                     failures,
                     errors,
+                    skipped,
+                    disabled,
                     test_suites,
                 }
             })

--- a/crates/quick-junit/src/report.rs
+++ b/crates/quick-junit/src/report.rs
@@ -58,6 +58,24 @@ pub struct Report {
     /// The total number of errors from all TestSuites.
     pub errors: usize,
 
+    /// The total number of tests skipped at runtime across all TestSuites.
+    ///
+    /// This is an extension to the spec that's used by nextest.
+    pub skipped: usize,
+
+    /// The total number of tests disabled by design across all TestSuites.
+    ///
+    /// Unlike [`skipped`](Self::skipped), which counts tests skipped at runtime,
+    /// `disabled` counts tests disabled by design -- for example, googletest's
+    /// `DISABLED_` prefix. `None` means no child suite carried a `disabled`
+    /// count.
+    ///
+    /// [`Self::add_test_suite`] aggregates the `disabled` counts of suites
+    /// which carry that field, but `quick-junit` itself has no notion of
+    /// disabled tests. Suite-level `disabled` counts can be populated either by
+    /// the deserializer or through manual assignment.
+    pub disabled: Option<usize>,
+
     /// The test suites contained in this report.
     pub test_suites: Vec<TestSuite>,
 }
@@ -73,6 +91,8 @@ impl Report {
             tests: 0,
             failures: 0,
             errors: 0,
+            skipped: 0,
+            disabled: None,
             test_suites: vec![],
         }
     }
@@ -105,7 +125,12 @@ impl Report {
         self
     }
 
-    /// Adds a new TestSuite and updates the `tests`, `failures` and `errors` counts.
+    /// Adds a new TestSuite and updates the aggregate counts.
+    ///
+    /// This updates the `tests`, `skipped`, `failures`, and `errors` counts. If
+    /// the suite carries a `disabled` count, it is added into `disabled` as
+    /// well, initializing that field from `None` to `Some(0)` if necessary; a
+    /// suite with no `disabled` count leaves `disabled` untouched.
     ///
     /// When generating a new report, use of this method is recommended over adding to
     /// `self.TestSuites` directly.
@@ -113,11 +138,20 @@ impl Report {
         self.tests += test_suite.tests;
         self.failures += test_suite.failures;
         self.errors += test_suite.errors;
+        self.skipped += test_suite.skipped;
+        if let Some(disabled) = test_suite.disabled {
+            *self.disabled.get_or_insert(0) += disabled;
+        }
         self.test_suites.push(test_suite);
         self
     }
 
-    /// Adds several [`TestSuite`]s and updates the `tests`, `failures` and `errors` counts.
+    /// Adds several [`TestSuite`]s and updates the aggregate counts.
+    ///
+    /// This updates the `tests`, `skipped`, `failures`, and `errors` counts, and
+    /// the `disabled` count for any suites that carry one. See
+    /// [`add_test_suite`](Self::add_test_suite) for the details of `disabled`
+    /// aggregation.
     ///
     /// When generating a new report, use of this method is recommended over adding to
     /// `self.TestSuites` directly.
@@ -158,8 +192,19 @@ pub struct TestSuite {
     /// The total number of tests in this TestSuite.
     pub tests: usize,
 
-    /// The total number of disabled tests in this TestSuite.
-    pub disabled: usize,
+    /// The total number of tests skipped at runtime in this TestSuite.
+    pub skipped: usize,
+
+    /// The number of tests in this TestSuite disabled by design.
+    ///
+    /// Unlike [`skipped`](Self::skipped), which counts tests skipped at
+    /// runtime, `disabled` counts tests disabled by design -- for example,
+    /// googletest's `DISABLED_` prefix. `None` means the `<testsuite>` element
+    /// carried no `disabled` attribute.
+    ///
+    /// `quick-junit` itself has no notion of disabled tests. This field is
+    /// populated by the deserializer or set manually.
+    pub disabled: Option<usize>,
 
     /// The total number of tests in this suite that errored.
     ///
@@ -201,7 +246,8 @@ impl TestSuite {
             time: None,
             timestamp: None,
             tests: 0,
-            disabled: 0,
+            skipped: 0,
+            disabled: None,
             errors: 0,
             failures: 0,
             test_cases: vec![],
@@ -253,7 +299,7 @@ impl TestSuite {
                 NonSuccessKind::Failure => self.failures += 1,
                 NonSuccessKind::Error => self.errors += 1,
             },
-            TestCaseStatus::Skipped { .. } => self.disabled += 1,
+            TestCaseStatus::Skipped { .. } => self.skipped += 1,
         }
         self.test_cases.push(test_case);
         self

--- a/crates/quick-junit/src/serialize.rs
+++ b/crates/quick-junit/src/serialize.rs
@@ -58,6 +58,8 @@ pub(crate) fn serialize_report_impl(
         tests,
         failures,
         errors,
+        skipped,
+        disabled,
         test_suites,
     } = report;
 
@@ -65,9 +67,13 @@ pub(crate) fn serialize_report_impl(
     testsuites_tag.extend_attributes([
         ("name", name.as_str()),
         ("tests", tests.to_string().as_str()),
+        ("skipped", skipped.to_string().as_str()),
         ("failures", failures.to_string().as_str()),
         ("errors", errors.to_string().as_str()),
     ]);
+    if let Some(disabled) = disabled {
+        testsuites_tag.push_attribute(("disabled", disabled.to_string().as_str()));
+    }
     if let Some(uuid) = uuid {
         testsuites_tag.push_attribute(("uuid", uuid.to_string().as_str()));
     }
@@ -97,6 +103,7 @@ pub(crate) fn serialize_test_suite(
     let TestSuite {
         name,
         tests,
+        skipped,
         disabled,
         errors,
         failures,
@@ -113,10 +120,13 @@ pub(crate) fn serialize_test_suite(
     test_suite_tag.extend_attributes([
         ("name", name.as_str()),
         ("tests", tests.to_string().as_str()),
-        ("disabled", disabled.to_string().as_str()),
+        ("skipped", skipped.to_string().as_str()),
         ("errors", errors.to_string().as_str()),
         ("failures", failures.to_string().as_str()),
     ]);
+    if let Some(disabled) = disabled {
+        test_suite_tag.push_attribute(("disabled", disabled.to_string().as_str()));
+    }
 
     if let Some(timestamp) = timestamp {
         serialize_timestamp(&mut test_suite_tag, timestamp);


### PR DESCRIPTION
We're going to start emitting skipped tests in https://github.com/nextest-rs/nextest/pull/3472. Prepare for that by aggregating counts into a `skipped` attribute.

* On `<testsuite>`, `skipped` matches the llg and Jenkins junit-10 schemas as well as pytest and Maven Surefire.
* The root-level `skipped` aggregate is a quick-junit extension matching the modern convention.

Preserve `disabled` for googletest and prior-version compatibility.