### PR TITLE
report: make name field optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+### Other changes
+
+- Reports without a `name` attribute can now be deserialized correctly.
+
 ## [0.7.0] - 2026-07-20
 
 ### Changed

--- a/crates/quick-junit-tests/tests/integration/deserialize.rs
+++ b/crates/quick-junit-tests/tests/integration/deserialize.rs
@@ -30,14 +30,10 @@ fn test_testsuites_missing_name() {
 <testsuites tests="0" failures="0" errors="0">
 </testsuites>"#;
 
-    assert_error(
-        xml,
-        |kind| matches!(kind, DeserializeErrorKind::MissingAttribute(_)),
-        &[
-            PathElement::TestSuites,
-            PathElement::Attribute("name".to_string()),
-        ],
-    );
+    // Should succeed - report doesn't need to have a name
+    let report = Report::deserialize_from_str(xml).unwrap();
+    assert!(report.name.is_none());
+    assert_eq!(report.tests, 0);
 }
 
 #[test]
@@ -645,7 +641,7 @@ fn test_empty_testsuites_element() {
 <testsuites name="test" tests="0" failures="0" errors="0"/>"#;
 
     let report = Report::deserialize_from_str(xml).unwrap();
-    assert_eq!(report.name.as_str(), "test");
+    assert_eq!(report.name.unwrap().as_str(), "test");
     assert_eq!(report.test_suites.len(), 0);
 }
 
@@ -655,7 +651,7 @@ fn test_empty_testsuites_with_all_attributes() {
 <testsuites name="test" uuid="550e8400-e29b-41d4-a716-446655440000" timestamp="2023-01-01T00:00:00Z" time="1.5" tests="0" failures="0" errors="0"/>"#;
 
     let report = Report::deserialize_from_str(xml).unwrap();
-    assert_eq!(report.name.as_str(), "test");
+    assert_eq!(report.name.unwrap().as_str(), "test");
     assert_eq!(
         report.uuid.unwrap().to_string(),
         "550e8400-e29b-41d4-a716-446655440000"
@@ -1060,7 +1056,7 @@ fn test_unknown_testsuites_attributes() {
 
     // Should succeed - unknown attributes on testsuites are ignored
     let report = Report::deserialize_from_str(xml).unwrap();
-    assert_eq!(report.name.as_str(), "test");
+    assert_eq!(report.name.unwrap().as_str(), "test");
 }
 
 #[test]
@@ -1070,7 +1066,7 @@ fn test_empty_testsuites_unknown_attributes() {
 
     // Should succeed - unknown attributes on empty testsuites are ignored
     let report = Report::deserialize_from_str(xml).unwrap();
-    assert_eq!(report.name.as_str(), "test");
+    assert_eq!(report.name.unwrap().as_str(), "test");
 }
 
 #[test]
@@ -1078,14 +1074,10 @@ fn test_empty_testsuites_missing_name() {
     let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="0" failures="0" errors="0"/>"#;
 
-    assert_error(
-        xml,
-        |kind| matches!(kind, DeserializeErrorKind::MissingAttribute(_)),
-        &[
-            PathElement::TestSuites,
-            PathElement::Attribute("name".to_string()),
-        ],
-    );
+    // Should succeed - report doesn't need to have a name
+    let report = Report::deserialize_from_str(xml).unwrap();
+    assert!(report.name.is_none());
+    assert_eq!(report.tests, 0);
 }
 
 #[test]

--- a/crates/quick-junit-tests/tests/integration/fixture_tests.rs
+++ b/crates/quick-junit-tests/tests/integration/fixture_tests.rs
@@ -205,7 +205,7 @@ fn deserialize_minimal_report() {
 "#;
 
     let report = Report::deserialize_from_str(xml).expect("deserializing minimal report succeeds");
-    assert_eq!(report.name.as_str(), "minimal");
+    assert_eq!(report.name.unwrap().as_str(), "minimal");
     assert_eq!(report.tests, 0);
     assert_eq!(report.failures, 0);
     assert_eq!(report.errors, 0);
@@ -258,14 +258,6 @@ fn deserialize_with_extra_attributes() {
 
 #[test]
 fn deserialize_error_handling() {
-    // Test missing required attribute
-    let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="0" failures="0" errors="0">
-</testsuites>
-"#;
-    let result = Report::deserialize_from_str(xml);
-    assert!(result.is_err());
-
     // Test invalid XML
     let xml = r#"<testsuites name="test" tests="0">"#;
     let result = Report::deserialize_from_str(xml);

--- a/crates/quick-junit/src/deserialize.rs
+++ b/crates/quick-junit/src/deserialize.rs
@@ -54,7 +54,7 @@ impl Report {
     /// "#;
     ///
     /// let report = Report::deserialize_from_str(xml).unwrap();
-    /// assert_eq!(report.name.as_str(), "my-test-run");
+    /// assert_eq!(report.name.unwrap().as_str(), "my-test-run");
     /// assert_eq!(report.tests, 1);
     /// ```
     pub fn deserialize_from_str(xml: &str) -> Result<Self, DeserializeError> {
@@ -188,8 +188,6 @@ fn parse_testsuites_element(
             _ => {} // Ignore unknown attributes.
         }
     }
-
-    let name = require_attribute(name, "name", path)?;
 
     Ok(Report {
         name,
@@ -1234,7 +1232,7 @@ mod tests {
 "#;
 
         let report = Report::deserialize_from_str(xml).unwrap();
-        assert_eq!(report.name.as_str(), "my-test-run");
+        assert_eq!(report.name.unwrap().as_str(), "my-test-run");
         assert_eq!(report.tests, 1);
         assert_eq!(report.failures, 0);
         assert_eq!(report.errors, 0);

--- a/crates/quick-junit/src/proptest_impls.rs
+++ b/crates/quick-junit/src/proptest_impls.rs
@@ -211,7 +211,7 @@ impl Arbitrary for Report {
                 };
 
                 Report {
-                    name,
+                    name: Some(name),
                     uuid,
                     timestamp,
                     time,

--- a/crates/quick-junit/src/report.rs
+++ b/crates/quick-junit/src/report.rs
@@ -33,7 +33,7 @@ pub type ReportUuid = TypedUuid<ReportKind>;
 #[non_exhaustive]
 pub struct Report {
     /// The name of this report.
-    pub name: XmlString,
+    pub name: Option<XmlString>,
 
     /// A unique identifier associated with this report.
     ///
@@ -85,7 +85,7 @@ impl Report {
     /// Creates a new `Report` with the given name.
     pub fn new(name: impl Into<XmlString>) -> Self {
         Self {
-            name: name.into(),
+            name: Some(name.into()),
             uuid: None,
             timestamp: None,
             time: None,

--- a/crates/quick-junit/src/serialize.rs
+++ b/crates/quick-junit/src/serialize.rs
@@ -64,8 +64,10 @@ pub(crate) fn serialize_report_impl(
     } = report;
 
     let mut testsuites_tag = BytesStart::new(TESTSUITES_TAG);
+    if let Some(name) = name {
+        testsuites_tag.push_attribute(("name", name.as_str()));
+    }
     testsuites_tag.extend_attributes([
-        ("name", name.as_str()),
         ("tests", tests.to_string().as_str()),
         ("skipped", skipped.to_string().as_str()),
         ("failures", failures.to_string().as_str()),


### PR DESCRIPTION
Some tools, notably junit-xml from the Python ecosystem do not allow the user to add the name attribute to a report. quick-junit thus fails to parse junit.xml files generated with this library.

The XSD from the linked Jenkins junit docs also does not list the name for the Report as a required field.

This change makes quick-junit a little more compatible with the ecosystem.